### PR TITLE
Keyword for identifying line with video stream changed

### DIFF
--- a/elisaviihde.py
+++ b/elisaviihde.py
@@ -215,7 +215,7 @@ class elisaviihde:
     uridata = self.session.get(self.baseurl + "/tallenteet/katso/" + str(programid), verify=self.verifycerts)
     self.checkrequest(uridata.status_code)
     for line in uridata.text.split("\n"):
-      if "new Player" in line:
+      if "recording-player" in line:
         return re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', line)[0]
 
   def markwatched(self, programid=0):

--- a/tests.py
+++ b/tests.py
@@ -24,7 +24,7 @@ def elisaviihde_api_mock(url, request):
   elif url.path == "/tallenteet/api/recordings/0":
     return {'status_code': 200, 'content': '[{"name":"dummy-recording"}]'}
   elif url.path == "/tallenteet/katso/0":
-    return {'status_code': 200, 'content': 'new Player http://test.com/test'}
+    return {'status_code': 200, 'content': 'data-section="recording-player" data-url="http://test.com/test"'}
   elif url.path == "/ohjelmaopas/ohjelma/1234":
     return {'status_code': 200, 'content': '\n<p itemprop="name">dummy-channel-name</p>\n'
               + '<p itemprop="description">dummy-service-description</p>\n'


### PR DESCRIPTION
Changed the keyword for identifying the line with the video stream in getstreamuri due to changes on the elisa viihde website. I have tested this change ONLY with the XBMC plugin https://github.com/anylonen/XBMC-Elisa-Viihde-plugin
